### PR TITLE
Coerce bad geoids to NaN

### DIFF
--- a/src/python/census/assemble_data.py
+++ b/src/python/census/assemble_data.py
@@ -251,7 +251,7 @@ class DataPlan:
             self.data[new_varname] = self.data[variable] / self.data['arealand']
 
         self.data.drop(columns='arealand', inplace=True)
-        self.data['geoid'] = pd.to_numeric(self.data['geoid'])
+        self.data['geoid'] = pd.to_numeric(self.data['geoid'], errors='coerce')
 
     def interpolate(self, method="ma", min_year=None, max_year=None):
         """


### PR DESCRIPTION
```
  File "/root/anaconda/envs/nsaph/lib/python3.8/site-packages/census/calculate_density.py", line 57, in <module>
    census.calculate_densities(context.densities)
  File "/root/anaconda/envs/nsaph/lib/python3.8/site-packages/census/assemble_data.py", line 263, in calculate_densities
    self.data['geoid'] = pd.to_numeric(self.data['geoid'])
  File "/root/anaconda/envs/nsaph/lib/python3.8/site-packages/pandas/core/tools/numeric.py", line 152, in to_numeric
    values = lib.maybe_convert_numeric(
  File "pandas/_libs/lib.pyx", line 2041, in pandas._libs.lib.maybe_convert_numeric
ValueError: Unable to parse string "006HH" at position 44
```